### PR TITLE
Fix menu endpoint

### DIFF
--- a/wp-content/mu-plugins/wuxt-headless-wp-api-extensions/classes/menu-array.class.php
+++ b/wp-content/mu-plugins/wuxt-headless-wp-api-extensions/classes/menu-array.class.php
@@ -17,14 +17,11 @@
 
     		$filter = is_callable($filter) ? $filter : null;
     		if (empty($menuName)) {
-    			throw new Exception('No menu location name provided.');
+    			throw new Exception('No menu name provided.');
     			return;
     		}
-    		$menuLocations = get_nav_menu_locations();
 
-    		if (empty($menuLocations[$menuName])) return;
-
-    		$this->menu = $this->retrieveMenu(wp_get_nav_menu_object($menuLocations[$menuName]), $args, $filter);
+    		$this->menu = $this->retrieveMenu(wp_get_nav_menu_object($menuName), $args, $filter);
     	}
 
 


### PR DESCRIPTION
There was an issue with the menu endpoint which was throwing an error.  

The code inside the constructor was assuming the first parameter was a menu location instead of a menu name. I just removed the code which was looking for the menu name in the locations array and just used the menu name directly.

The endpoint does not throw an error anymore and returns the menu items array as expected.