### PR TITLE
fix: add missing permission_callbacks to wuxt headless wp api extensi…

### DIFF
--- a/wp-content/mu-plugins/wuxt-headless-wp-api-extensions/extensions/front-page.php
+++ b/wp-content/mu-plugins/wuxt-headless-wp-api-extensions/extensions/front-page.php
@@ -10,7 +10,10 @@
     function wuxt_front_page_route() {
         register_rest_route('wuxt', '/v1/front-page', array(
             'methods'  => 'GET',
-            'callback' => 'wuxt_get_front_page'
+            'callback' => 'wuxt_get_front_page',
+            'permission_callback' => function () {
+                return '__return_true';
+            },
         ));
     }
 

--- a/wp-content/mu-plugins/wuxt-headless-wp-api-extensions/extensions/generate.php
+++ b/wp-content/mu-plugins/wuxt-headless-wp-api-extensions/extensions/generate.php
@@ -11,6 +11,9 @@
         register_rest_route('wuxt', '/v1/generate', array(
             'methods'  => 'GET',
             'callback' => 'wuxt_get_generate_urls'
+            'permission_callback' => function () {
+                return '__return_true';
+            },
         ));
     }
 

--- a/wp-content/mu-plugins/wuxt-headless-wp-api-extensions/extensions/menu.php
+++ b/wp-content/mu-plugins/wuxt-headless-wp-api-extensions/extensions/menu.php
@@ -11,6 +11,9 @@ function wuxt_route_menu()
     register_rest_route('wuxt', '/v1/menu', array(
         'methods' => 'GET',
         'callback' => 'wuxt_get_menu',
+        'permission_callback' => function () {
+            return '__return_true';
+        },
     ));
 }
 

--- a/wp-content/mu-plugins/wuxt-headless-wp-api-extensions/extensions/slug.php
+++ b/wp-content/mu-plugins/wuxt-headless-wp-api-extensions/extensions/slug.php
@@ -10,6 +10,9 @@
         register_rest_route('wuxt', '/v1/slug/(?P<slug>\S+)', array(
             'methods'  => 'GET',
             'callback' => 'wuxt_get_slug'
+            'permission_callback' => function () {
+                return '__return_true';
+            },
         ));
     }
 


### PR DESCRIPTION
### Add missing permission_callbacks to wuxt headless wp api extension api endpoints

```
Notice: register_rest_route was called incorrectly. The REST API route definition for wuxt/v1/front-page is missing the required permission_callback argument. For REST API routes that are intended to be public, use __return_true as the permission callback.
```